### PR TITLE
Cache uploaded files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
         "psr-4": {
             "Ycs77\\LaravelWizard\\Test\\": "tests"
         },
+        "files": [
+            "tests/utils.php"
+        ],
         "classmap": [
             "tests/Stubs/database/migrations"
         ]

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -53,6 +53,7 @@ class CacheManager extends Manager
     {
         return new SessionStore(
             $this->app['session.store'],
+            $this->app->make(CachedFileSerializer::class),
             $this->getSessionKey()
         );
     }
@@ -66,7 +67,12 @@ class CacheManager extends Manager
     {
         $table = $this->wizard->option('table');
 
-        return new DatabaseStore($this->getDatabaseConnection(), $table, $this->app);
+        return new DatabaseStore(
+            $this->getDatabaseConnection(),
+            $table,
+            $this->app->make(CachedFileSerializer::class),
+            $this->app
+        );
     }
 
     /**

--- a/src/CachedFile.php
+++ b/src/CachedFile.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Ycs77\LaravelWizard;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+class CachedFile
+{
+    /**
+     * The temporary storage disk.
+     *
+     * @var string
+     */
+    protected $disk;
+
+    /**
+     * The uploaded file instance.
+     *
+     * @var \Illuminate\Http\UploadedFile|null
+     */
+    protected $file;
+
+    /**
+     * The temporary filename.
+     *
+     * @var string
+     */
+    protected $filename;
+
+    /**
+     * The fake temporary filename for testing.
+     *
+     * @var string|null
+     */
+    protected static $fakeFilename;
+
+    /**
+     * The uploaded file temporary directory in app storage.
+     *
+     * @var string
+     */
+    protected $tmpDir;
+
+    /**
+     * The fake temporary directory for testing.
+     *
+     * @var string|null
+     */
+    protected static $fakeTmpDir;
+
+    /**
+     * The uploaded file temporary path in app storage.
+     *
+     * @var string
+     */
+    protected $tmpPath;
+
+    /**
+     * The uploaded file mimeType.
+     *
+     * @var string
+     */
+    protected $mimeType;
+
+    /**
+     * Create a new cached file instance.
+     *
+     * @param  \Illuminate\Http\UploadedFile  $file
+     * @param  string|null  $filename
+     * @param  string|null  $tmpDir
+     * @return void
+     */
+    public function __construct(UploadedFile $file, string $filename = null, string $tmpDir = null)
+    {
+        $this->disk = 'local';
+        $this->file = $file;
+        $this->filename = $this->generateFilename($file, $filename);
+        $this->tmpDir = $tmpDir ?? static::$fakeTmpDir ?? 'laravel-wizard-tmp';
+        $this->mimeType = $file->getMimeType();
+    }
+
+    /**
+     * Get the uploaded file instance.
+     *
+     * @return \Illuminate\Http\UploadedFile|null
+     */
+    public function file()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Get the temporary filename.
+     *
+     * @return string
+     */
+    public function filename()
+    {
+        return $this->filename;
+    }
+
+    /**
+     * Generate the temporary filename.
+     *
+     * @param  \Illuminate\Http\UploadedFile  $file
+     * @param  string|null  $filename
+     * @return string
+     */
+    public function generateFilename(UploadedFile $file, string $filename = null)
+    {
+        if ($filename = $filename ?? static::$fakeFilename) {
+            if ($extension = $file->extension()) {
+                $filename .= '.'.$extension;
+            }
+
+            return $filename;
+        }
+
+        return $file->hashName();
+    }
+
+    /**
+     * Set the fake temporary filename for testing.
+     *
+     * @param  string  $filename
+     * @return void
+     */
+    public static function setFakeFilename(string $filename)
+    {
+        static::$fakeFilename = $filename;
+    }
+
+    /**
+     * Get the fake temporary directory for testing.
+     *
+     * @return string
+     */
+    public function tmpDir()
+    {
+        return $this->tmpDir;
+    }
+
+    /**
+     * Set the fake temporary directory for testing.
+     *
+     * @param  string  $dir
+     * @return void
+     */
+    public static function setFakeTmpDir(string $dir)
+    {
+        static::$fakeTmpDir = $dir;
+    }
+
+    /**
+     * Get the temporary file path.
+     *
+     * @return string
+     */
+    public function tmpPath()
+    {
+        return $this->tmpPath;
+    }
+
+    /**
+     * Set the temporary file path.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function setTmpPath(string $path)
+    {
+        $this->tmpPath = $path;
+
+        return $this;
+    }
+
+    /**
+     * Get the full temporary file path.
+     *
+     * @return string
+     */
+    public function tmpFullPath()
+    {
+        return str_replace('\\', '/', $this->storage()->path($this->tmpPath));
+    }
+
+    /**
+     * Get the temporary file MIME type.
+     *
+     * @return string
+     */
+    public function mimeType()
+    {
+        return $this->mimeType;
+    }
+
+    /**
+     * Serialize the cached file.
+     *
+     * @return void
+     */
+    public function serialize()
+    {
+        if (! $this->tmpPath) {
+            $this->tmpPath = $this->file->storeAs($this->tmpDir, $this->filename, [
+                'disk' => $this->disk,
+            ]);
+        }
+    }
+
+    /**
+     * Unserialize the cached file.
+     *
+     * @return void
+     */
+    public function unserialize()
+    {
+        if (is_file($this->tmpFullPath()) && ! $this->file) {
+            $tmpFileInOs = tempnam(sys_get_temp_dir(), 'php');
+            copy($this->tmpFullPath(), $tmpFileInOs);
+            $this->file = new UploadedFile($tmpFileInOs, basename($tmpFileInOs), $this->mimeType);
+        }
+    }
+
+    /**
+     * Get the stoage disk instance.
+     *
+     * @return \Illuminate\Filesystem\FilesystemAdapter
+     */
+    protected function storage()
+    {
+        return Storage::disk($this->disk);
+    }
+
+    /**
+     * Get the stoage disk.
+     *
+     * @return string
+     */
+    public function disk()
+    {
+        return $this->disk;
+    }
+
+    /**
+     * Set the stoage disk.
+     *
+     * @param  string  $disk
+     * @return $this
+     */
+    public function setDisk(string $disk)
+    {
+        $this->disk = $disk;
+
+        return $this;
+    }
+
+    /**
+     * Prepare the object for serialization.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        $this->serialize();
+
+        return ['disk', 'filename', 'tmpDir', 'tmpPath', 'mimeType'];
+    }
+
+    /**
+     * When a CachedFile is being unserialized.
+     *
+     * @return void
+     */
+    public function __wakeup()
+    {
+        $this->unserialize();
+    }
+}

--- a/src/CachedFileSerializer.php
+++ b/src/CachedFileSerializer.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Ycs77\LaravelWizard;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+
+class CachedFileSerializer
+{
+    /**
+     * Serialize the cached file.
+     *
+     * @param  \Ycs77\LaravelWizard\CachedFile|\Illuminate\Http\UploadedFile  $file
+     * @param  string|null  $filename
+     * @param  string|null  $tmpDir
+     * @return string
+     */
+    public function serializeFile($file, string $filename = null, string $tmpDir = null)
+    {
+        if ($file instanceof UploadedFile) {
+            $file = new CachedFile($file, $filename, $tmpDir);
+        }
+
+        return CachedFile::class.':'.serialize($file);
+    }
+
+    /**
+     * Unserialize the cached file.
+     *
+     * @param  string  $data
+     * @return \Ycs77\LaravelWizard\CachedFile
+     */
+    public function unserializeFile(string $data)
+    {
+        return unserialize((string) str_replace(CachedFile::class.':', '', $data));
+    }
+
+    /**
+     * Serialize the cached files of payload.
+     *
+     * @param  array  $data
+     * @param  array  $cachedData
+     * @param  string|null  $filename
+     * @param  string|null  $tmpDir
+     * @return array
+     */
+    public function serializePayloadFiles(array $data, array $cachedData, string $filename = null, string $tmpDir = null)
+    {
+        $files = $data['_files'] ?? $cachedData['_files'] ?? [];
+
+        foreach ($data as $stepKey => $stepData) {
+            if (is_array($stepData)) {
+                foreach ($stepData as $stepDataKey => $stepInput) {
+                    if ($stepInput instanceof UploadedFile) {
+                        // check if is exists the uploaded temp file.
+                        if ($serializedData = Arr::get($cachedData, "$stepKey.$stepDataKey")) {
+                            // keep exists temp file.
+                            $data[$stepKey][$stepDataKey] = $serializedData;
+                        } else {
+                            // store temp file.
+                            $cachedFile = new CachedFile($stepInput, $filename, $tmpDir);
+                            $data[$stepKey][$stepDataKey] = $this->serializeFile($cachedFile);
+                            $files[] = $cachedFile->tmpFullPath();
+                        }
+                    }
+                }
+            }
+        }
+
+        $data['_files'] = $files;
+
+        return $data;
+    }
+
+    /**
+     * Unserialize the cached files of payload.
+     *
+     * @param  array  $data
+     * @return array
+     */
+    public function unserializePayloadFiles(array $data)
+    {
+        foreach ($data as $stepKey => $stepData) {
+            if (is_array($stepData)) {
+                foreach ($stepData as $stepDataKey => $stepInput) {
+                    if ($this->canUnserializeFile($stepInput)) {
+                        $data[$stepKey][$stepDataKey] = $this->unserializeFile($stepInput)->file();
+                    }
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Check the data is can be unserialized.
+     *
+     * @param  mixed  $data
+     * @return bool
+     */
+    public function canUnserializeFile($data)
+    {
+        return is_string($data) && substr($data, 0, strlen(CachedFile::class.':')) === CachedFile::class.':';
+    }
+
+    /**
+     * Clean the temporary files.
+     *
+     * @param  array  $files
+     * @return void
+     */
+    public function clearTmpFiles(array $files = [])
+    {
+        foreach ($files as $path) {
+            @unlink($path);
+        }
+    }
+}

--- a/tests/Concerns/CachedFileTesting.php
+++ b/tests/Concerns/CachedFileTesting.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Ycs77\LaravelWizard\Test\Concerns;
+
+use Illuminate\Support\Facades\Storage;
+
+trait CachedFileTesting
+{
+    protected function getSerializedCachedFile()
+    {
+        if (jpg() === 'jpeg') {
+            return "Ycs77\LaravelWizard\CachedFile:O:30:\"Ycs77\LaravelWizard\CachedFile\":5:{s:7:\"\x00*\x00disk\";s:5:\"local\";s:11:\"\x00*\x00filename\";s:19:\"test_temp_file.jpeg\";s:9:\"\x00*\x00tmpDir\";s:18:\"laravel-wizard-tmp\";s:10:\"\x00*\x00tmpPath\";s:38:\"laravel-wizard-tmp/test_temp_file.jpeg\";s:11:\"\x00*\x00mimeType\";s:10:\"image/jpeg\";}";
+        }
+
+        return "Ycs77\LaravelWizard\CachedFile:O:30:\"Ycs77\LaravelWizard\CachedFile\":5:{s:7:\"\x00*\x00disk\";s:5:\"local\";s:11:\"\x00*\x00filename\";s:18:\"test_temp_file.jpg\";s:9:\"\x00*\x00tmpDir\";s:18:\"laravel-wizard-tmp\";s:10:\"\x00*\x00tmpPath\";s:37:\"laravel-wizard-tmp/test_temp_file.jpg\";s:11:\"\x00*\x00mimeType\";s:10:\"image/jpeg\";}";
+    }
+
+    protected function tempFileFullPath($num = '')
+    {
+        return str_replace('\\', '/', Storage::path('laravel-wizard-tmp/test_temp_file'.$num.'.'.jpg()));
+    }
+}

--- a/tests/Feature/HttpTest.php
+++ b/tests/Feature/HttpTest.php
@@ -157,7 +157,7 @@ class HttpTest extends TestCase
             'avatar' => $file,
         ]);
         $response->assertRedirect('/wizard/upload-file/save-avatar-step-stub');
-        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.'.jpg());
 
         // Get avatar step
         $response = $this->get('/wizard/upload-file/save-avatar-step-stub');
@@ -166,7 +166,7 @@ class HttpTest extends TestCase
         // Post avatar step
         $response = $this->post('/wizard/upload-file/save-avatar-step-stub');
         $response->assertRedirect('/wizard/upload-file/done');
-        Storage::assertMissing('laravel-wizard-tmp/test_temp_file.jpg');
+        Storage::assertMissing('laravel-wizard-tmp/test_temp_file.'.jpg());
 
         // Get done page
         $response = $this->get('/wizard/upload-file/done');

--- a/tests/Feature/HttpTest.php
+++ b/tests/Feature/HttpTest.php
@@ -3,6 +3,9 @@
 namespace Ycs77\LaravelWizard\Test\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Ycs77\LaravelWizard\CachedFile;
 use Ycs77\LaravelWizard\Facades\Wizard;
 use Ycs77\LaravelWizard\Test\TestCase;
 
@@ -90,7 +93,7 @@ class HttpTest extends TestCase
         ]);
     }
 
-    public function testRunAllWizardStepsCloseCache()
+    public function testRunAllWizardStepsButNoCache()
     {
         $this->app['config']->set('wizard.cache', false);
 
@@ -128,6 +131,50 @@ class HttpTest extends TestCase
         $this->assertDatabaseHas('posts', [
             'title' => 'Title',
             'content' => 'Content.',
+        ]);
+    }
+
+    public function testRunAllWizardStepsSaveOnLastStepAndCanBeCachedUploadedFile()
+    {
+        $this->app['config']->set('wizard.cache', true);
+
+        Storage::fake('local');
+
+        $this->setWizardRoutes(
+            '/wizard/upload-file',
+            '\Ycs77\LaravelWizard\Test\Stubs\WizardControllerUploadFileStub',
+            'wizard.upload-file'
+        );
+
+        // Get avatar step
+        $response = $this->get('/wizard/upload-file/avatar-step-stub');
+        $response->assertStatus(200);
+
+        // Post avatar step
+        CachedFile::setFakeFilename('test_temp_file');
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $response = $this->post('/wizard/upload-file/avatar-step-stub', [
+            'avatar' => $file,
+        ]);
+        $response->assertRedirect('/wizard/upload-file/save-avatar-step-stub');
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+
+        // Get avatar step
+        $response = $this->get('/wizard/upload-file/save-avatar-step-stub');
+        $response->assertStatus(200);
+
+        // Post avatar step
+        $response = $this->post('/wizard/upload-file/save-avatar-step-stub');
+        $response->assertRedirect('/wizard/upload-file/done');
+        Storage::assertMissing('laravel-wizard-tmp/test_temp_file.jpg');
+
+        // Get done page
+        $response = $this->get('/wizard/upload-file/done');
+        $response->assertStatus(200);
+
+        Storage::assertExists('avatar/saved_avatar.jpg');
+        $this->assertDatabaseHas('users', [
+            'avatar' => 'avatar/saved_avatar.jpg',
         ]);
     }
 
@@ -184,6 +231,7 @@ class HttpTest extends TestCase
                 'content' => 'Content.',
             ],
             '_last_index' => 0,
+            '_files' => [],
         ], $this->app['session']->get('laravel_wizard.test'));
     }
 
@@ -213,6 +261,7 @@ class HttpTest extends TestCase
                 'content' => null,
             ],
             '_last_index' => 0,
+            '_files' => [],
         ], $this->app['session']->get('laravel_wizard.test'));
     }
 
@@ -236,6 +285,7 @@ class HttpTest extends TestCase
                 'name' => null,
             ],
             '_last_index' => 1,
+            '_files' => [],
         ], $this->app['session']->get('laravel_wizard.test'));
     }
 
@@ -267,7 +317,7 @@ class HttpTest extends TestCase
         $response->assertRedirect('/wizard/test/post-step-stub');
 
         $this->assertDatabaseHas('wizards', [
-            'payload' => '{"user-step-stub":{"name":"John"},"_last_index":1}',
+            'payload' => '{"user-step-stub":{"name":"John"},"_files":[],"_last_index":1}',
             'user_id' => 1,
         ]);
     }

--- a/tests/Stubs/AvatarStepStub.php
+++ b/tests/Stubs/AvatarStepStub.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Ycs77\LaravelWizard\Test\Stubs;
+
+use Illuminate\Http\Request;
+use Ycs77\LaravelWizard\Step;
+
+class AvatarStepStub extends Step
+{
+    /**
+     * The step slug.
+     *
+     * @var string
+     */
+    protected $slug = 'avatar-step-stub';
+
+    /**
+     * The step show label text.
+     *
+     * @var string
+     */
+    protected $label = 'Avatar step stub';
+
+    /**
+     * The step form view path.
+     *
+     * @var string
+     */
+    protected $view = 'steps.avatar';
+
+    /**
+     * Set the step model instance or the relationships instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation|null
+     */
+    public function model(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Save this step form data.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array|null  $data
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation|null  $model
+     * @return void
+     */
+    public function saveData(Request $request, $data = null, $model = null)
+    {
+        // cache avatar and store file on SaveAvatarStepStub.
+    }
+
+    /**
+     * Validation rules.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function rules(Request $request)
+    {
+        return [];
+    }
+}

--- a/tests/Stubs/SaveAvatarStepStub.php
+++ b/tests/Stubs/SaveAvatarStepStub.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Ycs77\LaravelWizard\Test\Stubs;
+
+use Illuminate\Http\Request;
+use Ycs77\LaravelWizard\Step;
+
+class SaveAvatarStepStub extends Step
+{
+    /**
+     * The step slug.
+     *
+     * @var string
+     */
+    protected $slug = 'save-avatar-step-stub';
+
+    /**
+     * The step show label text.
+     *
+     * @var string
+     */
+    protected $label = 'Save avatar step stub';
+
+    /**
+     * The step form view path.
+     *
+     * @var string
+     */
+    protected $view = 'steps.save-avatar';
+
+    /**
+     * Set the step model instance or the relationships instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation|null
+     */
+    public function model(Request $request)
+    {
+        return $request->user();
+    }
+
+    /**
+     * Save this step form data.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array|null  $data
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation|null  $model
+     * @return void
+     */
+    public function saveData(Request $request, $data = null, $model = null)
+    {
+        $data = $this->getStepsData();
+        $data['avatar'] = $data['avatar']->storeAs('avatar', 'saved_avatar.jpg');
+        $model->update($data);
+    }
+
+    /**
+     * Validation rules.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function rules(Request $request)
+    {
+        return [];
+    }
+}

--- a/tests/Stubs/User.php
+++ b/tests/Stubs/User.php
@@ -12,7 +12,10 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'name',
+        'email',
+        'avatar',
+        'password',
     ];
 
     /**
@@ -21,7 +24,8 @@ class User extends Authenticatable
      * @var array
      */
     protected $hidden = [
-        'password', 'remember_token',
+        'password',
+        'remember_token',
     ];
 
     /**

--- a/tests/Stubs/WizardControllerUploadFileStub.php
+++ b/tests/Stubs/WizardControllerUploadFileStub.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ycs77\LaravelWizard\Test\Stubs;
+
+class WizardControllerUploadFileStub extends WizardControllerStub
+{
+    /**
+     * The wizard steps instance.
+     *
+     * @var array
+     */
+    protected $steps = [
+        AvatarStepStub::class,
+        SaveAvatarStepStub::class,
+    ];
+}

--- a/tests/Stubs/database/migrations/0000_00_00_000000_create_wizard_test_tables.php
+++ b/tests/Stubs/database/migrations/0000_00_00_000000_create_wizard_test_tables.php
@@ -17,6 +17,7 @@ class CreateWizardTestTables extends Migration
             $table->bigIncrements('id');
             $table->string('name');
             $table->string('email')->unique();
+            $table->string('avatar')->nullable();
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();

--- a/tests/Stubs/views/steps/avatar.blade.php
+++ b/tests/Stubs/views/steps/avatar.blade.php
@@ -1,0 +1,8 @@
+<div class="form-group mb-3">
+    <label for="avatar">Avatar</label>
+    <input type="file" name="avatar" id="avatar" class="form-control">
+    <div class="form-control d-none {{ $errors->has('avatar') ? 'is-invalid' : '' }}"></div>
+    @if ($errors->has('avatar'))
+        <span class="invalid-feedback">{{ $errors->first('avatar') }}</span>
+    @endif
+</div>

--- a/tests/Stubs/views/steps/save-avatar.blade.php
+++ b/tests/Stubs/views/steps/save-avatar.blade.php
@@ -1,0 +1,1 @@
+{{-- is a empty step view --}}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Ycs77\LaravelWizard\Test;
 
+use Illuminate\Http\UploadedFile;
 use Mockery;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Ycs77\LaravelWizard\Facades\Wizard as WizardFacade;
@@ -100,5 +101,18 @@ class TestCase extends OrchestraTestCase
         $this->app['request']->setUserResolver(function () use ($user) {
             return $user;
         });
+    }
+
+    /**
+     * Assert that is temporary file.
+     *
+     * @param  mixed  $file
+     * @param  string  $startsWith
+     * @return void
+     */
+    protected function assertIsTemporaryFile($file, string $startsWith = 'php')
+    {
+        $this->assertInstanceOf(UploadedFile::class, $file);
+        $this->assertStringStartsWith($startsWith, $file->getFilename());
     }
 }

--- a/tests/Unit/CachedFileSerializerTest.php
+++ b/tests/Unit/CachedFileSerializerTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Ycs77\LaravelWizard\Test\Unit;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Ycs77\LaravelWizard\CachedFile;
+use Ycs77\LaravelWizard\CachedFileSerializer;
+use Ycs77\LaravelWizard\Test\TestCase;
+
+class CachedFileSerializerTest extends TestCase
+{
+    /**
+     * The cached file serializer instance.
+     *
+     * @var \Ycs77\LaravelWizard\CachedFileSerializer
+     */
+    protected $serializer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('local');
+
+        $this->serializer = new CachedFileSerializer();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->serializer = null;
+
+        parent::tearDown();
+    }
+
+    public function testSerializeFilePutUploadedFile()
+    {
+        // arrange
+        CachedFile::setFakeFilename('test_temp_file');
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $expected = $this->getSerializedCachedFile();
+
+        // act
+        $actual = $this->serializer->serializeFile($file);
+
+        // assert
+        $this->assertEquals($expected, $actual);
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+    }
+
+    public function testSerializeFilePutCachedFile()
+    {
+        // arrange
+        CachedFile::setFakeFilename('test_temp_file');
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $cachedFile = new CachedFile($file);
+        $expected = $this->getSerializedCachedFile();
+
+        // act
+        $actual = $this->serializer->serializeFile($cachedFile);
+
+        // assert
+        $this->assertEquals($expected, $actual);
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+    }
+
+    public function testUnserializeFile()
+    {
+        // arrange
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $filePath = $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $serialized = $this->getSerializedCachedFile();
+
+        // act
+        $cachedFile = $this->serializer->unserializeFile($serialized);
+        $cachedFile->setTmpPath($filePath);
+
+        // assert
+        $this->assertInstanceOf(CachedFile::class, $cachedFile);
+        $this->assertEquals('local', $cachedFile->disk());
+        $this->assertEquals('test_temp_file.jpg', $cachedFile->filename());
+        $this->assertEquals('image/jpeg', $cachedFile->mimeType());
+        $this->assertEquals('laravel-wizard-tmp/test_temp_file.jpg', $cachedFile->tmpPath());
+        $this->assertTrue(is_file($cachedFile->tmpFullPath()));
+        $this->assertIsTemporaryFile($cachedFile->file());
+    }
+
+    public function testFirstTimeSerializePayloadFiles()
+    {
+        // arrange
+        CachedFile::setFakeFilename('test_temp_file');
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $data = [
+            'other_step' => ['field' => 'data'],
+            'avatar_step' => ['avatar' => $file],
+        ];
+        $cachedData = [];
+        $expected = [
+            'other_step' => ['field' => 'data'],
+            'avatar_step' => ['avatar' => $this->getSerializedCachedFile()],
+            '_files' => [$this->tempFileFullPath()],
+        ];
+
+        // act
+        $actual = $this->serializer->serializePayloadFiles($data, $cachedData);
+
+        // assert
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testSecondTimeSerializePayloadFiles()
+    {
+        // arrange
+        CachedFile::setFakeFilename('test_temp_file');
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $data = [
+            'other_step' => ['field' => 'data'],
+            'avatar_step' => ['avatar' => $file],
+            '_files' => [$this->tempFileFullPath()],
+        ];
+        $cachedData = ['avatar_step' => ['avatar' => $this->getSerializedCachedFile()]];
+        $expected = [
+            'other_step' => ['field' => 'data'],
+            'avatar_step' => ['avatar' => $this->getSerializedCachedFile()],
+            '_files' => [$this->tempFileFullPath()],
+        ];
+
+        // act
+        $actual = $this->serializer->serializePayloadFiles($data, $cachedData);
+
+        // assert
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testUnserializePayloadFiles()
+    {
+        // arrange
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $data = [
+            'other_step' => ['field' => 'data'],
+            'avatar_step' => ['avatar' => $this->getSerializedCachedFile()],
+            '_files' => [$this->tempFileFullPath()],
+        ];
+
+        // act
+        $actual = $this->serializer->unserializePayloadFiles($data);
+
+        // assert
+        $this->assertEquals(['field' => 'data'], $actual['other_step']);
+        $this->assertIsTemporaryFile($actual['avatar_step']['avatar']);
+        $this->assertEquals([$this->tempFileFullPath()], $actual['_files']);
+    }
+
+    public function testCanBeUnserializeFile()
+    {
+        // arrange
+        $data = $this->getSerializedCachedFile();
+
+        // act
+        $actual = $this->serializer->canUnserializeFile($data);
+
+        // assert
+        $this->assertTrue($actual);
+    }
+
+    public function testCanNotBeUnserializeFile()
+    {
+        // arrange
+        $data = $this->getSerializedCachedFile();
+
+        // act
+        $actual1 = $this->serializer->canUnserializeFile(str_replace(CachedFile::class, 'FakePrefix', $data));
+        $actual2 = $this->serializer->canUnserializeFile(null);
+
+        // assert
+        $this->assertFalse($actual1, 'is string type but is no correct prefix');
+        $this->assertFalse($actual2, 'is not string type');
+    }
+
+    public function testClearTmpFiles()
+    {
+        // arrange
+        $file = UploadedFile::fake()->image('avatar1.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file1.jpg');
+        $file = UploadedFile::fake()->image('avatar2.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file2.jpg');
+        $files = [
+            $this->tempFileFullPath('1'),
+            $this->tempFileFullPath('2'),
+        ];
+
+        // act
+        Storage::assertExists([
+            'laravel-wizard-tmp/test_temp_file1.jpg',
+            'laravel-wizard-tmp/test_temp_file2.jpg',
+        ]);
+        $this->serializer->clearTmpFiles($files);
+
+        // assert
+        Storage::assertMissing([
+            'laravel-wizard-tmp/test_temp_file1.jpg',
+            'laravel-wizard-tmp/test_temp_file2.jpg',
+        ]);
+    }
+
+    protected function getSerializedCachedFile()
+    {
+        return "Ycs77\LaravelWizard\CachedFile:O:30:\"Ycs77\LaravelWizard\CachedFile\":5:{s:7:\"\x00*\x00disk\";s:5:\"local\";s:11:\"\x00*\x00filename\";s:18:\"test_temp_file.jpg\";s:9:\"\x00*\x00tmpDir\";s:18:\"laravel-wizard-tmp\";s:10:\"\x00*\x00tmpPath\";s:37:\"laravel-wizard-tmp/test_temp_file.jpg\";s:11:\"\x00*\x00mimeType\";s:10:\"image/jpeg\";}";
+    }
+
+    protected function tempFileFullPath($num = '')
+    {
+        return str_replace('\\', '/', Storage::path('laravel-wizard-tmp/test_temp_file'.$num.'.jpg'));
+    }
+}

--- a/tests/Unit/CachedFileSerializerTest.php
+++ b/tests/Unit/CachedFileSerializerTest.php
@@ -6,10 +6,13 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Ycs77\LaravelWizard\CachedFile;
 use Ycs77\LaravelWizard\CachedFileSerializer;
+use Ycs77\LaravelWizard\Test\Concerns\CachedFileTesting;
 use Ycs77\LaravelWizard\Test\TestCase;
 
 class CachedFileSerializerTest extends TestCase
 {
+    use CachedFileTesting;
+
     /**
      * The cached file serializer instance.
      *
@@ -45,7 +48,7 @@ class CachedFileSerializerTest extends TestCase
 
         // assert
         $this->assertEquals($expected, $actual);
-        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.'.jpg());
     }
 
     public function testSerializeFilePutCachedFile()
@@ -61,14 +64,14 @@ class CachedFileSerializerTest extends TestCase
 
         // assert
         $this->assertEquals($expected, $actual);
-        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.'.jpg());
     }
 
     public function testUnserializeFile()
     {
         // arrange
         $file = UploadedFile::fake()->image('avatar.jpg');
-        $filePath = $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $filePath = $file->storeAs('laravel-wizard-tmp', 'test_temp_file.'.jpg());
         $serialized = $this->getSerializedCachedFile();
 
         // act
@@ -78,9 +81,9 @@ class CachedFileSerializerTest extends TestCase
         // assert
         $this->assertInstanceOf(CachedFile::class, $cachedFile);
         $this->assertEquals('local', $cachedFile->disk());
-        $this->assertEquals('test_temp_file.jpg', $cachedFile->filename());
+        $this->assertEquals('test_temp_file.'.jpg(), $cachedFile->filename());
         $this->assertEquals('image/jpeg', $cachedFile->mimeType());
-        $this->assertEquals('laravel-wizard-tmp/test_temp_file.jpg', $cachedFile->tmpPath());
+        $this->assertEquals('laravel-wizard-tmp/test_temp_file.'.jpg(), $cachedFile->tmpPath());
         $this->assertTrue(is_file($cachedFile->tmpFullPath()));
         $this->assertIsTemporaryFile($cachedFile->file());
     }
@@ -136,7 +139,7 @@ class CachedFileSerializerTest extends TestCase
     {
         // arrange
         $file = UploadedFile::fake()->image('avatar.jpg');
-        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.'.jpg());
         $data = [
             'other_step' => ['field' => 'data'],
             'avatar_step' => ['avatar' => $this->getSerializedCachedFile()],
@@ -182,35 +185,21 @@ class CachedFileSerializerTest extends TestCase
     {
         // arrange
         $file = UploadedFile::fake()->image('avatar1.jpg');
-        $file->storeAs('laravel-wizard-tmp', 'test_temp_file1.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file1.'.jpg());
         $file = UploadedFile::fake()->image('avatar2.jpg');
-        $file->storeAs('laravel-wizard-tmp', 'test_temp_file2.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file2.'.jpg());
         $files = [
             $this->tempFileFullPath('1'),
             $this->tempFileFullPath('2'),
         ];
 
         // act
-        Storage::assertExists([
-            'laravel-wizard-tmp/test_temp_file1.jpg',
-            'laravel-wizard-tmp/test_temp_file2.jpg',
-        ]);
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file1.'.jpg());
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file2.'.jpg());
         $this->serializer->clearTmpFiles($files);
 
         // assert
-        Storage::assertMissing([
-            'laravel-wizard-tmp/test_temp_file1.jpg',
-            'laravel-wizard-tmp/test_temp_file2.jpg',
-        ]);
-    }
-
-    protected function getSerializedCachedFile()
-    {
-        return "Ycs77\LaravelWizard\CachedFile:O:30:\"Ycs77\LaravelWizard\CachedFile\":5:{s:7:\"\x00*\x00disk\";s:5:\"local\";s:11:\"\x00*\x00filename\";s:18:\"test_temp_file.jpg\";s:9:\"\x00*\x00tmpDir\";s:18:\"laravel-wizard-tmp\";s:10:\"\x00*\x00tmpPath\";s:37:\"laravel-wizard-tmp/test_temp_file.jpg\";s:11:\"\x00*\x00mimeType\";s:10:\"image/jpeg\";}";
-    }
-
-    protected function tempFileFullPath($num = '')
-    {
-        return str_replace('\\', '/', Storage::path('laravel-wizard-tmp/test_temp_file'.$num.'.jpg'));
+        Storage::assertMissing('laravel-wizard-tmp/test_temp_file1.'.jpg());
+        Storage::assertMissing('laravel-wizard-tmp/test_temp_file2.'.jpg());
     }
 }

--- a/tests/Unit/DatabaseStoreTest.php
+++ b/tests/Unit/DatabaseStoreTest.php
@@ -8,10 +8,12 @@ use Illuminate\Support\Facades\Storage;
 use Ycs77\LaravelWizard\CachedFile;
 use Ycs77\LaravelWizard\CachedFileSerializer;
 use Ycs77\LaravelWizard\DatabaseStore;
+use Ycs77\LaravelWizard\Test\Concerns\CachedFileTesting;
 use Ycs77\LaravelWizard\Test\TestCase;
 
 class DatabaseStoreTest extends TestCase
 {
+    use CachedFileTesting;
     use RefreshDatabase;
 
     /**
@@ -123,7 +125,7 @@ class DatabaseStoreTest extends TestCase
 
         // arrange
         $file = UploadedFile::fake()->image('avatar.jpg');
-        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.'.jpg());
         $this->app['db']->table('wizards')->insert([
             'payload' => '{"avatar_step":{"avatar":'.json_encode($this->getSerializedCachedFile()).'}}',
             'user_id' => 1,
@@ -259,27 +261,17 @@ class DatabaseStoreTest extends TestCase
 
         // arrange
         $file = UploadedFile::fake()->image('avatar.jpg');
-        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.'.jpg());
         $this->app['db']->table('wizards')->insert([
             'payload' => '{"step":{"field":"data"},"_files":['.json_encode($this->tempFileFullPath()).'],"_last_index":1}',
             'user_id' => 1,
         ]);
 
         // act
-        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.'.jpg());
         $this->cache->clear();
 
         // assert
-        Storage::assertMissing('laravel-wizard-tmp/test_temp_file.jpg');
-    }
-
-    protected function getSerializedCachedFile()
-    {
-        return "Ycs77\LaravelWizard\CachedFile:O:30:\"Ycs77\LaravelWizard\CachedFile\":5:{s:7:\"\x00*\x00disk\";s:5:\"local\";s:11:\"\x00*\x00filename\";s:18:\"test_temp_file.jpg\";s:9:\"\x00*\x00tmpDir\";s:18:\"laravel-wizard-tmp\";s:10:\"\x00*\x00tmpPath\";s:37:\"laravel-wizard-tmp/test_temp_file.jpg\";s:11:\"\x00*\x00mimeType\";s:10:\"image/jpeg\";}";
-    }
-
-    protected function tempFileFullPath()
-    {
-        return str_replace('\\', '/', Storage::path('laravel-wizard-tmp/test_temp_file.jpg'));
+        Storage::assertMissing('laravel-wizard-tmp/test_temp_file.'.jpg());
     }
 }

--- a/tests/Unit/DatabaseStoreTest.php
+++ b/tests/Unit/DatabaseStoreTest.php
@@ -3,6 +3,10 @@
 namespace Ycs77\LaravelWizard\Test\Unit;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Ycs77\LaravelWizard\CachedFile;
+use Ycs77\LaravelWizard\CachedFileSerializer;
 use Ycs77\LaravelWizard\DatabaseStore;
 use Ycs77\LaravelWizard\Test\TestCase;
 
@@ -31,6 +35,7 @@ class DatabaseStoreTest extends TestCase
         $this->cache = $this->app->makeWith(DatabaseStore::class, [
             'connection' => $connection,
             'table' => $table,
+            'serializer' => $this->app->make(CachedFileSerializer::class),
             'container' => $this->app,
         ]);
     }
@@ -112,6 +117,25 @@ class DatabaseStoreTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testGetDataWithFile()
+    {
+        $this->authenticate();
+
+        // arrange
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $this->app['db']->table('wizards')->insert([
+            'payload' => '{"avatar_step":{"avatar":'.json_encode($this->getSerializedCachedFile()).'}}',
+            'user_id' => 1,
+        ]);
+
+        // act
+        $actual = $this->cache->get('avatar_step.avatar');
+
+        // assert
+        $this->assertIsTemporaryFile($actual);
+    }
+
     public function testGetLastProcessedIndexData()
     {
         $this->authenticate();
@@ -129,7 +153,7 @@ class DatabaseStoreTest extends TestCase
         $this->assertEquals(0, $actual);
     }
 
-    public function testSetData()
+    public function testSetAllData()
     {
         $this->authenticate();
 
@@ -138,7 +162,7 @@ class DatabaseStoreTest extends TestCase
 
         // assert
         $this->assertDatabaseHas('wizards', [
-            'payload' => '{"step":{"field":"data"}}',
+            'payload' => '{"step":{"field":"data"},"_files":[]}',
             'user_id' => 1,
         ]);
     }
@@ -152,7 +176,28 @@ class DatabaseStoreTest extends TestCase
 
         // assert
         $this->assertDatabaseHas('wizards', [
-            'payload' => '{"step":{"field":"data"},"_last_index":1}',
+            'payload' => '{"step":{"field":"data"},"_files":[],"_last_index":1}',
+            'user_id' => 1,
+        ]);
+    }
+
+    public function testSetDataWithFile()
+    {
+        $this->authenticate();
+
+        // arrange
+        CachedFile::setFakeFilename('test_temp_file');
+        $file = UploadedFile::fake()->image('avatar.jpg');
+
+        // act
+        $this->cache->set([
+            'other_step' => ['field' => 'data'],
+            'avatar_step' => ['avatar' => $file],
+        ]);
+
+        // assert
+        $this->assertDatabaseHas('wizards', [
+            'payload' => '{"other_step":{"field":"data"},"avatar_step":{"avatar":'.json_encode($this->getSerializedCachedFile()).'},"_files":['.json_encode($this->tempFileFullPath()).']}',
             'user_id' => 1,
         ]);
     }
@@ -166,7 +211,7 @@ class DatabaseStoreTest extends TestCase
 
         // assert
         $this->assertDatabaseHas('wizards', [
-            'payload' => '{"step":{"field":"data"}}',
+            'payload' => '{"step":{"field":"data"},"_files":[]}',
             'user_id' => 1,
         ]);
     }
@@ -194,7 +239,7 @@ class DatabaseStoreTest extends TestCase
 
         // arrange
         $this->app['db']->table('wizards')->insert([
-            'payload' => '{"step":{"field":"data"},"_last_index":1}',
+            'payload' => '{"step":{"field":"data"},"_files":[],"_last_index":1}',
             'user_id' => 1,
         ]);
 
@@ -203,8 +248,38 @@ class DatabaseStoreTest extends TestCase
 
         // assert
         $this->assertDatabaseMissing('wizards', [
-            'payload' => '{"step":{"field":"data"},"_last_index":1}',
+            'payload' => '{"step":{"field":"data"},"_files":[],"_last_index":1}',
             'user_id' => 1,
         ]);
+    }
+
+    public function testClearDataAndFile()
+    {
+        $this->authenticate();
+
+        // arrange
+        $file = UploadedFile::fake()->image('avatar.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $this->app['db']->table('wizards')->insert([
+            'payload' => '{"step":{"field":"data"},"_files":['.json_encode($this->tempFileFullPath()).'],"_last_index":1}',
+            'user_id' => 1,
+        ]);
+
+        // act
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+        $this->cache->clear();
+
+        // assert
+        Storage::assertMissing('laravel-wizard-tmp/test_temp_file.jpg');
+    }
+
+    protected function getSerializedCachedFile()
+    {
+        return "Ycs77\LaravelWizard\CachedFile:O:30:\"Ycs77\LaravelWizard\CachedFile\":5:{s:7:\"\x00*\x00disk\";s:5:\"local\";s:11:\"\x00*\x00filename\";s:18:\"test_temp_file.jpg\";s:9:\"\x00*\x00tmpDir\";s:18:\"laravel-wizard-tmp\";s:10:\"\x00*\x00tmpPath\";s:37:\"laravel-wizard-tmp/test_temp_file.jpg\";s:11:\"\x00*\x00mimeType\";s:10:\"image/jpeg\";}";
+    }
+
+    protected function tempFileFullPath()
+    {
+        return str_replace('\\', '/', Storage::path('laravel-wizard-tmp/test_temp_file.jpg'));
     }
 }

--- a/tests/Unit/SessionStoreTest.php
+++ b/tests/Unit/SessionStoreTest.php
@@ -7,10 +7,13 @@ use Illuminate\Support\Facades\Storage;
 use Ycs77\LaravelWizard\CachedFile;
 use Ycs77\LaravelWizard\CachedFileSerializer;
 use Ycs77\LaravelWizard\SessionStore;
+use Ycs77\LaravelWizard\Test\Concerns\CachedFileTesting;
 use Ycs77\LaravelWizard\Test\TestCase;
 
 class SessionStoreTest extends TestCase
 {
+    use CachedFileTesting;
+
     /**
      * The wizard store instance.
      *
@@ -93,7 +96,7 @@ class SessionStoreTest extends TestCase
     {
         // arrange
         $file = UploadedFile::fake()->image('avatar.jpg');
-        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.'.jpg());
         $this->session([
             'laravel_wizard.test' => [
                 'avatar_step' => ['avatar' => $this->getSerializedCachedFile()],
@@ -227,7 +230,7 @@ class SessionStoreTest extends TestCase
     {
         // arrange
         $file = UploadedFile::fake()->image('avatar.jpg');
-        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.jpg');
+        $file->storeAs('laravel-wizard-tmp', 'test_temp_file.'.jpg());
         $this->session([
             'laravel_wizard.test' => [
                 'step' => ['field' => 'data'],
@@ -236,20 +239,10 @@ class SessionStoreTest extends TestCase
         ]);
 
         // act
-        Storage::assertExists('laravel-wizard-tmp/test_temp_file.jpg');
+        Storage::assertExists('laravel-wizard-tmp/test_temp_file.'.jpg());
         $this->cache->clear();
 
         // assert
-        Storage::assertMissing('laravel-wizard-tmp/test_temp_file.jpg');
-    }
-
-    protected function getSerializedCachedFile()
-    {
-        return "Ycs77\LaravelWizard\CachedFile:O:30:\"Ycs77\LaravelWizard\CachedFile\":5:{s:7:\"\x00*\x00disk\";s:5:\"local\";s:11:\"\x00*\x00filename\";s:18:\"test_temp_file.jpg\";s:9:\"\x00*\x00tmpDir\";s:18:\"laravel-wizard-tmp\";s:10:\"\x00*\x00tmpPath\";s:37:\"laravel-wizard-tmp/test_temp_file.jpg\";s:11:\"\x00*\x00mimeType\";s:10:\"image/jpeg\";}";
-    }
-
-    protected function tempFileFullPath()
-    {
-        return str_replace('\\', '/', Storage::path('laravel-wizard-tmp/test_temp_file.jpg'));
+        Storage::assertMissing('laravel-wizard-tmp/test_temp_file.'.jpg());
     }
 }

--- a/tests/utils.php
+++ b/tests/utils.php
@@ -1,0 +1,31 @@
+<?php
+
+if (! function_exists('jpg')) {
+    /**
+     * Polyfill guess .jpg / .jpeg extension.
+     *
+     * @return string
+     */
+    function jpg()
+    {
+        if (app()->bound('test.polyfill-jpg')) {
+            return app('test.polyfill-jpg');
+        }
+
+        if (class_exists(\Symfony\Component\Mime\MimeTypes::class)) {
+            $jpg = \Symfony\Component\Mime\MimeTypes::getDefault()->getExtensions('image/jpeg')[0];
+            app()->instance('test.polyfill-jpg', $jpg);
+
+            return $jpg;
+        }
+
+        if (class_exists(\Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser::class)) {
+            $jpg = \Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuessers::getInstance()->guess('image/jpeg');
+            app()->instance('test.polyfill-jpg', $jpg);
+
+            return $jpg;
+        }
+
+        return 'jpg';
+    }
+}


### PR DESCRIPTION
fix #21
fix #9

Serialize the uploaded files on cached the input data, fixed `Serialization of 'UploadedFile' is not allowed` error.